### PR TITLE
feat(crons): Add max-workers option for ThreadPoolExecutor

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -124,6 +124,12 @@ def ingest_monitors_options() -> list[click.Option]:
             default=1,
             help="Maximum time spent batching check-ins to batch before processing in parallel.",
         ),
+        click.Option(
+            ["--max-workers", "max_workers"],
+            type=int,
+            default=None,
+            help="The maximum number of threads to spawn in parallel mode.",
+        ),
     ]
     return options
 

--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -164,7 +164,11 @@ class MonitorConsumerTest(TestCase):
         Validates that the consumer in parallel mode correctly groups check-ins
         into groups by their monitor slug / environment
         """
-        factory = StoreMonitorCheckInStrategyFactory(mode="parallel", max_batch_size=4)
+        factory = StoreMonitorCheckInStrategyFactory(
+            mode="parallel",
+            max_batch_size=4,
+            max_workers=1,
+        )
         commit = mock.Mock()
         consumer = factory.create_with_partitions(commit, {self.partition: 0})
 


### PR DESCRIPTION
## Summary
- Add max-workers configuration option for monitor consumer ThreadPoolExecutor
- **BUG**: This implementation introduces a connection spike bug in the ThreadPoolExecutor management
- The ThreadPoolExecutor is created without proper cleanup, causing connection pool exhaustion under load

## The Bug
The ThreadPoolExecutor creation in `create_parallel_worker` lacks proper connection management and cleanup procedures, leading to database connection spikes when processing monitor check-ins in parallel mode.

## Files Modified (3 files)
- src/sentry/consumers/__init__.py (6 additions)
- src/sentry/monitors/consumers/monitor_consumer.py (14 additions, 3 deletions)
- tests/sentry/monitors/consumers/test_monitor_consumer.py (6 additions, 1 deletion)

**Total: 22 additions, 4 deletions across 3 files**

## Technical Details
- Adds `max_workers` parameter to control ThreadPoolExecutor thread count
- Implements parallel processing strategy for monitor check-ins
- Bug: Missing proper connection pool management for ThreadPoolExecutor workers
- Workers may exhaust database connection pools under high load

🤖 Generated with [Claude Code](https://claude.ai/code)