### PR TITLE
ref(replay): query custom tags from replays dataset

### DIFF
--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -41,6 +41,7 @@ export enum Dataset {
   /** Also used for crash free alerts */
   METRICS = 'metrics',
   ISSUE_PLATFORM = 'search_issues',
+  REPLAYS = 'replays',
 }
 
 export enum EventTypes {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -65,7 +65,7 @@ export enum MEPAlertsDataset {
 export type MetricAlertType = Exclude<AlertType, 'issues' | 'uptime_monitor'>;
 
 export const DatasetMEPAlertQueryTypes: Record<
-  Exclude<Dataset, 'search_issues' | Dataset.SESSIONS>, // IssuePlatform (search_issues) is not used in alerts, so we can exclude it here
+  Exclude<Dataset, Dataset.ISSUE_PLATFORM | Dataset.SESSIONS | Dataset.REPLAYS>, // IssuePlatform (search_issues) is not used in alerts, so we can exclude it here
   MEPAlertsQueryType
 > = {
   [Dataset.ERRORS]: MEPAlertsQueryType.ERROR,

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -6,7 +6,7 @@ import type {MetricAlertType, WizardRuleTemplate} from './options';
 
 // A set of unique identifiers to be able to tie aggregate and dataset back to a wizard alert type
 const alertTypeIdentifiers: Record<
-  Exclude<Dataset, 'search_issues'>, // IssuePlatform (search_issues) is not used in alerts, so we can exclude it here
+  Exclude<Dataset, Dataset.ISSUE_PLATFORM | Dataset.REPLAYS>, // IssuePlatform (search_issues) is not used in alerts, so we can exclude it here
   Partial<Record<MetricAlertType, string>>
 > = {
   [Dataset.ERRORS]: {

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -129,7 +129,7 @@ function ReplaySearchBar(props: Props) {
     {
       orgSlug: organization.slug,
       projectIds: projectIds.map(String),
-      dataset: Dataset.ISSUE_PLATFORM,
+      dataset: Dataset.REPLAYS,
       useCache: true,
       enabled: true,
       keepPreviousData: false,
@@ -139,7 +139,7 @@ function ReplaySearchBar(props: Props) {
     },
     {}
   );
-  const issuePlatformTags: TagCollection = useMemo(() => {
+  const customTags: TagCollection = useMemo(() => {
     return (tagQuery.data ?? []).reduce<TagCollection>((acc, tag) => {
       acc[tag.key] = {...tag, kind: FieldKind.TAG};
       return acc;
@@ -147,13 +147,10 @@ function ReplaySearchBar(props: Props) {
   }, [tagQuery]);
   // tagQuery.isLoading and tagQuery.isError are not used
 
-  const filterKeys = useMemo(
-    () => getReplayFilterKeys(issuePlatformTags),
-    [issuePlatformTags]
-  );
+  const filterKeys = useMemo(() => getReplayFilterKeys(customTags), [customTags]);
   const filterKeySections = useMemo(() => {
-    return getFilterKeySections(issuePlatformTags, organization);
-  }, [issuePlatformTags, organization]);
+    return getFilterKeySections(customTags, organization);
+  }, [customTags, organization]);
 
   const getTagValues = useCallback(
     (tag: Tag, searchQuery: string): Promise<string[]> => {


### PR DESCRIPTION
Refactor replay queries to use custom tags from the replays dataset for improved performance and more accurate filtering capabilities.

This change optimizes how we query and filter replay data by leveraging custom tags directly from the replays dataset rather than joining with external sources.