### PR TITLE
alert rules can be fetched via projects fk

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -155,10 +155,9 @@ class AlertRuleSerializer(Serializer):
                 for project in alert_rule.projects.all():
                     alert_rule_projects.add((alert_rule.id, project.slug))
 
-        # TODO - Cleanup Subscription Project Mapping
         snuba_alert_rule_projects = AlertRule.objects.filter(
             id__in=[item.id for item in item_list]
-        ).values_list("id", "snuba_query__subscriptions__project__slug")
+        ).values_list("id", "projects__slug")
 
         alert_rule_projects.update(
             [(id, project_slug) for id, project_slug in snuba_alert_rule_projects if project_slug]

--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -6,7 +6,7 @@ from ..base import BulkModelDeletionTask, ModelDeletionTask, ModelRelation
 class ProjectDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry.discover.models import DiscoverSavedQueryProject
-        from sentry.incidents.models.alert_rule import AlertRule
+        from sentry.incidents.models.alert_rule import AlertRule, AlertRuleProjects
         from sentry.incidents.models.incident import IncidentProject
         from sentry.models.activity import Activity
         from sentry.models.appconnectbuilds import AppConnectBuild
@@ -51,6 +51,7 @@ class ProjectDeletionTask(ModelDeletionTask):
         # in bulk
         for m in (
             Activity,
+            AlertRuleProjects,
             AppConnectBuild,
             EnvironmentProject,
             GroupAssignee,

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -27,9 +27,7 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
             raise PermissionDenied
 
         try:
-            kwargs["alert_rule"] = AlertRule.objects.get(
-                snuba_query__subscriptions__project=project, id=alert_rule_id
-            )
+            kwargs["alert_rule"] = AlertRule.objects.get(projects=project, id=alert_rule_id)
         except AlertRule.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -38,9 +38,7 @@ class ProjectAlertRuleTaskDetailsEndpoint(ProjectEndpoint):
 
         if rule_id and status == "success":
             try:
-                alert_rule = AlertRule.objects.get(
-                    snuba_query__subscriptions__project=project, id=rule_id
-                )
+                alert_rule = AlertRule.objects.get(projects=project, id=rule_id)
                 context["alertRule"] = serialize(alert_rule, request.user)
             except AlertRule.DoesNotExist:
                 raise Http404

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar, Protocol, Self
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
@@ -89,18 +89,12 @@ class AlertRuleManager(BaseManager["AlertRule"]):
     def fetch_for_organization(self, organization, projects=None):
         queryset = self.filter(organization=organization)
         if projects is not None:
-            # TODO - Cleanup Subscription Project Mapping
-            queryset = queryset.filter(
-                Q(snuba_query__subscriptions__project__in=projects) | Q(projects__in=projects)
-            ).distinct()
+            queryset = queryset.filter(projects__in=projects).distinct()
 
         return queryset
 
     def fetch_for_project(self, project):
-        # TODO - Cleanup Subscription Project Mapping
-        return self.filter(
-            Q(snuba_query__subscriptions__project=project) | Q(projects=project)
-        ).distinct()
+        return self.filter(projects=project).distinct()
 
     @classmethod
     def __build_subscription_cache_key(cls, subscription_id):

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -29,9 +29,7 @@ class BaseAlertRuleSerializerTest:
         self, alert_rule, result, skip_dates=False, resolve_threshold=NOT_SET
     ):
         alert_rule_projects = sorted(
-            AlertRule.objects.filter(id=alert_rule.id).values_list(
-                "snuba_query__subscriptions__project__slug", flat=True
-            )
+            AlertRule.objects.filter(id=alert_rule.id).values_list("projects__slug", flat=True)
         )
         assert result["id"] == str(alert_rule.id)
         assert result["organizationId"] == str(alert_rule.organization_id)
@@ -184,8 +182,9 @@ class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
         assert result[1]["projects"] == [
             project.slug for project in activated_alert_rule.projects.all()
         ]
+        # NOTE: we are now _only_ referencing alert_rule.projects fk (AlertRuleProjects)
         assert result[2]["projects"] == [
-            project.slug for project in activated_alert_rule.projects.all()
+            project.slug for project in alert_rule_no_projects.projects.all()
         ]
 
     def test_environment(self):

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 from django.utils import timezone
 
-from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleProjects
 from sentry.models.dashboard_widget import DashboardWidgetQuery, DashboardWidgetQueryOnDemand
 from sentry.models.environment import Environment
 from sentry.models.project import Project
@@ -63,8 +63,11 @@ def create_alert(
     )
 
     alert_rule = AlertRule.objects.create(
-        snuba_query=snuba_query, threshold_period=1, organization=project.organization
+        snuba_query=snuba_query,
+        threshold_period=1,
+        organization=project.organization,
     )
+    AlertRuleProjects.objects.create(alert_rule=alert_rule, project=project)
 
     return alert_rule
 


### PR DESCRIPTION
Improve alert rule fetching by enabling retrieval via projects foreign key relationship for better performance and data consistency.

This change optimizes how alert rules are queried and accessed through the project relationship.