### PR TITLE
fix(issue-views): Fix query being overwritten on default tab

### DIFF
--- a/static/app/views/issueList/customViewsHeader.tsx
+++ b/static/app/views/issueList/customViewsHeader.tsx
@@ -156,6 +156,9 @@ function CustomViewsIssueListHeaderTabsContent({
 
   const getInitialTabKey = () => {
     if (draggableTabs[0].key.startsWith('default')) {
+      if (query) {
+        return TEMPORARY_TAB_KEY;
+      }
       return draggableTabs[0].key;
     }
     if (!query && !sort && !viewId) {


### PR DESCRIPTION
Fix issue where the query parameter was being overwritten when switching to the default tab in issue views.

This resolves a synchronization issue that could cause data inconsistencies in the UI.