### PR TITLE
ref(grouping): Add logging to debug missing grouphash metadata

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1317,6 +1317,22 @@ def assign_event_to_group(
 
     # From here on out, we're just doing housekeeping
 
+    # TODO: Temporary metric to debug missing grouphash metadata. This metric *should* exactly match
+    # the `grouping.grouphashmetadata.backfill_needed` metric collected in
+    # `get_or_create_grouphashes`. If it doesn't, perhaps there's a race condition between creation
+    # of the metadata and our ability to pull it from the database immediately thereafter.
+    for grouphash in [*primary.grouphashes, *secondary.grouphashes]:
+        if not grouphash.metadata:
+            logger.warning(
+                "grouphash_metadata.hash_without_metadata",
+                extra={
+                    "event_id": event.event_id,
+                    "project_id": project.id,
+                    "hash": grouphash.hash,
+                },
+            )
+            metrics.incr("grouping.grouphashmetadata.backfill_needed_2", sample_rate=1.0)
+
     # Background grouping is a way for us to get performance metrics for a new
     # config without having it actually affect on how events are grouped. It runs
     # either before or after the main grouping logic, depending on the option value.

--- a/src/sentry/grouping/ingest/grouphash_metadata.py
+++ b/src/sentry/grouping/ingest/grouphash_metadata.py
@@ -111,15 +111,28 @@ METRICS_TAGS_BY_HASH_BASIS = {
 def should_handle_grouphash_metadata(project: Project, grouphash_is_new: bool) -> bool:
     # Killswitches
     if not options.get("grouping.grouphash_metadata.ingestion_writes_enabled"):
+        metrics.incr(
+            "grouping.grouphash_metadata.should_handle",
+            tags={"result": False, "reason": "killswitch"},
+        )
         return False
 
     # While we're backfilling metadata for existing grouphash records, if the load is too high, we
     # want to prioritize metadata for new grouphashes because there's certain information
     # (timestamp, Seer data) which is only available at group creation time.
     if grouphash_is_new:
+        metrics.incr(
+            "grouping.grouphash_metadata.should_handle",
+            tags={"result": True, "reason": "new_group"},
+        )
         return True
     else:
-        return random.random() <= options.get("grouping.grouphash_metadata.backfill_sample_rate")
+        result = random.random() <= options.get("grouping.grouphash_metadata.backfill_sample_rate")
+        metrics.incr(
+            "grouping.grouphash_metadata.should_handle",
+            tags={"result": result, "reason": f"die_roll_{result}"},
+        )
+        return result
 
 
 def create_or_update_grouphash_metadata_if_needed(


### PR DESCRIPTION
Even though in theory all grouphashes, new and old, should be getting grouphash metadata, we're still seeing on average 2K+ grouphashes per day which are missing metadata. (We check after metadata should have been added.) These hits aren't guaranteed to be unique, by any means - we're quite possibly seeing a given grouphash multiple times in that count - but even so, seeing the same grouphash more than once means we're missing multiple opportunities to add metadata to it. Over the last month we have logged a _few_ errors in metadata creation (18, to be exact), but that's obviously not nearly enough to explain the ~70K times we've encountered a hash without metadata.

To try to debug this, this PR does a few things:

- Add a second `backfill_needed` metric later on in the ingest process. It should match the first `backfill_needed` metric, but if it doesn't, maybe we're dealing with a race condition between creating the metadata and checking for it.

- Add a log when we're missing metadata, so we can see if maybe there's a race condition between events with the same hash.

- Add a metric to the function gating metadata creation, to make sure that our 100% sample rate is actually working out to be 100%.