### PR TITLE
ref(issue-platform): Compare types instead of categories for mismatch during ingest

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -276,11 +276,11 @@ def save_issue_from_occurrence(
         return None
     else:
         group = primary_grouphash.group
-        if group.issue_category.value != occurrence.type.category:
+        if group.issue_type.type_id != occurrence.type.type_id:
             logger.error(
-                "save_issue_from_occurrence.category_mismatch",
+                "save_issue_from_occurrence.type_mismatch",
                 extra={
-                    "issue_category": group.issue_category,
+                    "issue_type": group.issue_type.slug,
                     "occurrence_type": occurrence.type.slug,
                     "event_type": "platform",
                     "group_id": group.id,

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -198,7 +198,7 @@ SAMPLE_TO_OCCURRENCE_MAP = {
         uuid.uuid4().hex,
         1,
         uuid.uuid4().hex,
-        ["e714d718cb4e7d3ce1ad800f7f33d223"],
+        ["fed5919bb4cbfc1883a7284fb5946e17"],
         "N+1 API Call",
         "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
         None,

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -354,7 +354,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         )
         assert set(hash_fingerprint(other_fingerprint)) == other_grouphashes
 
-    def test_existing_group_different_category(self) -> None:
+    def test_existing_group_different_type(self) -> None:
         event = self.store_event(data={}, project_id=self.project.id)
         occurrence = self.build_occurrence(fingerprint=["some-fingerprint"])
         group_info = save_issue_from_occurrence(occurrence, event, None)
@@ -367,12 +367,12 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
         with mock.patch("sentry.issues.ingest.logger") as logger:
             assert save_issue_from_occurrence(new_occurrence, new_event, None) is None
             logger.error.assert_called_once_with(
-                "save_issue_from_occurrence.category_mismatch",
+                "save_issue_from_occurrence.type_mismatch",
                 extra={
-                    "issue_category": group_info.group.issue_category,
+                    "issue_type": group_info.group.issue_type.slug,
+                    "occurrence_type": MonitorIncidentType.slug,
                     "event_type": "platform",
                     "group_id": group_info.group.id,
-                    "occurrence_type": "monitor_check_in_failure",
                 },
             )
 


### PR DESCRIPTION
Changes the issue platform ingestion logic to compare types instead of categories when detecting mismatches during the ingest process.