### PR TITLE
feat(replays): Emit breadcrumbs to EAP

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -504,6 +504,13 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Enables trace-item ingestion.
+register(
+    "replay.recording.ingest-trace-items.allow-list",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # User Feedback Options
 register(

--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -455,8 +455,12 @@ def as_log_message(event: dict[str, Any]) -> str | None:
                 return None
             case EventType.OPTIONS:
                 return None
+            case EventType.MEMORY:
+                return None
             case EventType.FEEDBACK:
                 return None  # the log message is processed before this method is called
+            case EventType.SLOW_CLICK:
+                return None
     except (KeyError, ValueError):
         logger.exception(
             "Error parsing event in replay AI summary",

--- a/src/sentry/replays/lib/kafka.py
+++ b/src/sentry/replays/lib/kafka.py
@@ -1,10 +1,34 @@
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from arroyo.types import Topic as ArroyoTopic
+from sentry_kafka_schemas.codecs import Codec
+from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
-from sentry.conf.types.kafka_definition import Topic
+from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.utils.arroyo_producer import SingletonProducer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 from sentry.utils.pubsub import KafkaPublisher
+
+#
+# EAP PRODUCER
+#
+
+
+EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
+
+
+def _get_eap_items_producer() -> KafkaProducer:
+    """Get a Kafka producer for EAP TraceItems."""
+    cluster_name = get_topic_definition(Topic.SNUBA_ITEMS)["cluster"]
+    producer_config = get_kafka_producer_cluster_options(cluster_name)
+    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+
+eap_producer = SingletonProducer(_get_eap_items_producer)
+
+
+#
+# REPLAY PRODUCER
+#
 
 
 def _get_ingest_replay_events_producer() -> KafkaProducer:
@@ -23,6 +47,10 @@ def publish_replay_event(message: str) -> None:
         payload=KafkaPayload(None, message.encode("utf-8"), []),
     )
 
+
+#
+# LEGACY PRODUCERS
+#
 
 # We keep a synchronous and asynchronous singleton because a shared singleton could lead
 # to synchronous publishing when asynchronous publishing was desired and vice-versa.

--- a/src/sentry/replays/usecases/ingest/event_logger.py
+++ b/src/sentry/replays/usecases/ingest/event_logger.py
@@ -5,15 +5,21 @@ from hashlib import md5
 from typing import Any, Literal, TypedDict
 
 import sentry_sdk
+from arroyo import Topic as ArroyoTopic
+from arroyo.backends.kafka import KafkaPayload
+from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
+from sentry import options
+from sentry.conf.types.kafka_definition import Topic
 from sentry.models.project import Project
-from sentry.replays.lib.kafka import publish_replay_event
+from sentry.replays.lib.kafka import EAP_ITEMS_CODEC, eap_producer, publish_replay_event
 from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta
 from sentry.replays.usecases.ingest.issue_creation import (
     report_hydration_error_issue_with_replay_event,
     report_rage_click_issue_with_replay_event,
 )
 from sentry.utils import json, metrics
+from sentry.utils.kafka_config import get_topic_definition
 
 logger = logging.getLogger()
 
@@ -259,6 +265,18 @@ def report_rage_click(
             click["component_name"],
             click["replay_event"],
         )
+
+
+@sentry_sdk.trace
+def emit_trace_items_to_eap(project_id: int, trace_items: list[TraceItem]) -> None:
+    """Emit trace-items to EAP."""
+    if project_id not in options.get("replay.recording.ingest-trace-items.allow-list"):
+        return None
+
+    topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
+    for trace_item in trace_items:
+        payload = KafkaPayload(None, EAP_ITEMS_CODEC.encode(trace_item), [])
+        eap_producer.produce(ArroyoTopic(topic), payload)
 
 
 @sentry_sdk.trace

--- a/tests/sentry/replays/unit/consumers/test_recording.py
+++ b/tests/sentry/replays/unit/consumers/test_recording.py
@@ -303,6 +303,7 @@ def test_process_message_compressed():
         recording_size_uncompressed=len(original_payload),
         recording_size=len(compressed_payload),
         replay_event={},
+        trace_items=[],
         video_size=None,
     )
     assert expected == processed_result
@@ -352,6 +353,7 @@ def test_process_message_uncompressed():
         recording_size_uncompressed=len(original_payload),
         recording_size=len(compressed_payload),
         replay_event={},
+        trace_items=[],
         video_size=None,
     )
     assert expected == processed_result
@@ -401,6 +403,7 @@ def test_process_message_compressed_with_video():
         recording_size_uncompressed=len(original_payload),
         recording_size=len(compressed_payload),
         replay_event={},
+        trace_items=[],
         video_size=5,
     )
     assert expected == processed_result

--- a/tests/sentry/replays/unit/test_event_logger.py
+++ b/tests/sentry/replays/unit/test_event_logger.py
@@ -1,7 +1,16 @@
 import uuid
 from unittest import mock
 
-from sentry.replays.usecases.ingest.event_logger import emit_click_events, gen_rage_clicks
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
+from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
+
+from sentry.conf.types.kafka_definition import Topic
+from sentry.replays.usecases.ingest.event_logger import (
+    emit_click_events,
+    emit_trace_items_to_eap,
+    gen_rage_clicks,
+)
 from sentry.replays.usecases.ingest.event_parser import ClickEvent, ParsedEventMeta
 
 
@@ -66,3 +75,67 @@ def test_emit_click_events_environment_handling():
         assert producer.call_args is not None
         assert producer.call_args.args[0].name == "ingest-replay-events"
         assert producer.call_args.args[1].value is not None
+
+
+@mock.patch("sentry.options.get")
+@mock.patch("arroyo.backends.kafka.consumer.KafkaProducer.produce")
+def test_emit_trace_items_to_eap(producer, options_get):
+    options_get.return_value = [1]
+
+    timestamp = Timestamp()
+    timestamp.FromMilliseconds(1000)
+
+    trace_items = [
+        TraceItem(
+            organization_id=1,
+            project_id=2,
+            trace_id=uuid.uuid4().hex,
+            item_id=uuid.uuid4().bytes,
+            item_type=TraceItemType.TRACE_ITEM_TYPE_REPLAY,
+            timestamp=timestamp,
+            attributes={},
+            client_sample_rate=1.0,
+            server_sample_rate=1.0,
+            retention_days=90,
+            received=timestamp,
+        )
+    ]
+
+    emit_trace_items_to_eap(1, trace_items)
+
+    assert options_get.called
+    assert producer.called
+    assert producer.call_args[0][0].name == Topic.SNUBA_ITEMS.value
+    assert producer.call_args[0][1].key is None
+    assert producer.call_args[0][1].headers == []
+    assert isinstance(producer.call_args[0][1].value, bytes)
+
+
+@mock.patch("sentry.options.get")
+@mock.patch("arroyo.backends.kafka.consumer.KafkaProducer.produce")
+def test_emit_trace_items_to_eap_option_blocked(producer, options_get):
+    options_get.return_value = []
+
+    timestamp = Timestamp()
+    timestamp.FromMilliseconds(1000)
+
+    trace_items = [
+        TraceItem(
+            organization_id=1,
+            project_id=2,
+            trace_id=uuid.uuid4().hex,
+            item_id=uuid.uuid4().bytes,
+            item_type=TraceItemType.TRACE_ITEM_TYPE_REPLAY,
+            timestamp=timestamp,
+            attributes={},
+            client_sample_rate=1.0,
+            server_sample_rate=1.0,
+            retention_days=90,
+            received=timestamp,
+        )
+    ]
+
+    emit_trace_items_to_eap(1, trace_items)
+
+    assert options_get.called
+    assert not producer.called


### PR DESCRIPTION
Problem statement: right now breadcrumbs are locked away in a file somewhere in storage. Let's index them so users can search their replays in new ways.