### PR TITLE
feat(agent-insights): Store selected span in url

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, memo, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -146,7 +146,7 @@ export function AISpanList({
   );
 }
 
-function TraceListItem({
+const TraceListItem = memo(function TraceListItem({
   node,
   onClick,
   isSelected,
@@ -188,7 +188,7 @@ function TraceListItem({
       </ListItemContent>
     </ListItemContainer>
   );
-}
+});
 
 const keyToTag = (key: string, type: 'string' | 'number') => {
   return `tags[${key},${type}]`;

--- a/static/app/views/insights/agentMonitoring/components/modelName.tsx
+++ b/static/app/views/insights/agentMonitoring/components/modelName.tsx
@@ -6,15 +6,21 @@ import {space} from 'sentry/styles/space';
 
 interface ModelNameProps {
   modelId: string;
+  gap?: string | number;
   provider?: string;
   size?: number;
 }
 
-export function ModelName({modelId, provider, size = 16}: ModelNameProps) {
+export function ModelName({
+  modelId,
+  provider,
+  size = 16,
+  gap = space(1),
+}: ModelNameProps) {
   const platform = getModelPlatform(modelId, provider);
 
   return (
-    <Flex gap={space(1)}>
+    <Flex gap={gap}>
       <IconWrapper>
         <PlatformIcon platform={platform ?? 'unknown'} size={size} />
       </IconWrapper>

--- a/static/app/views/insights/agentMonitoring/hooks/useLocationSyncedState.tsx
+++ b/static/app/views/insights/agentMonitoring/hooks/useLocationSyncedState.tsx
@@ -1,0 +1,84 @@
+import {startTransition, useCallback, useEffect, useRef, useState} from 'react';
+import type {LocationDescriptor, LocationDescriptorObject} from 'history';
+import omit from 'lodash/omit';
+
+import type {
+  decodeBoolean,
+  decodeInteger,
+  decodeList,
+  decodeScalar,
+  decodeSorts,
+  QueryValue,
+} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+type KnownDecoder =
+  | typeof decodeInteger
+  | typeof decodeList
+  | typeof decodeScalar
+  | typeof decodeSorts
+  | typeof decodeBoolean;
+
+type GenericDecoder<T = unknown> = (query: QueryValue) => T;
+
+type Decoder = KnownDecoder | GenericDecoder;
+
+/**
+ * Creates a local state that is synced with the URL.
+ * URL updates are deferred, so the UI will feel more responsive.
+ * @returns
+ */
+export function useLocationSyncedState<T extends Decoder>(key: string, decoder: T) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const fields = useLocationQuery({
+    fields: {
+      [key]: decoder,
+    },
+  });
+  const urlParam = fields[key];
+  const [state, setState] = useState(urlParam);
+
+  // Sync URL updates to the local state
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  useEffect(() => {
+    if (stateRef.current !== urlParam) {
+      setState(urlParam);
+    }
+  }, [urlParam]);
+
+  const updateLocation = useCallback(
+    (updater: (query: LocationDescriptorObject) => LocationDescriptor) => {
+      startTransition(() => {
+        navigate(updater(location), {replace: true, preventScrollReset: true});
+      });
+    },
+    [navigate, location]
+  );
+
+  const removeQueryParam = useCallback(() => {
+    updateLocation(prevLocation => ({
+      ...prevLocation,
+      query: omit(prevLocation.query, key),
+    }));
+  }, [updateLocation, key]);
+
+  const handleUpdate = useCallback(
+    (value: typeof urlParam) => {
+      setState(value);
+      updateLocation(prevLocation => ({
+        ...prevLocation,
+        query: {
+          ...prevLocation.query,
+          [key]: value,
+        },
+      }));
+    },
+    [updateLocation, key]
+  );
+
+  return [state, handleUpdate, removeQueryParam] as const;
+}

--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -1,10 +1,12 @@
 import Count from 'sentry/components/count';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {ModelName} from 'sentry/views/insights/agentMonitoring/components/modelName';
 import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
 import {formatLLMCosts} from 'sentry/views/insights/agentMonitoring/utils/formatLLMCosts';
 import {
@@ -83,7 +85,7 @@ export function getHighlightedSpanAttributes({
   if (model) {
     highlightedAttributes.push({
       name: t('Model'),
-      value: model,
+      value: <ModelName modelId={model} gap={space(0.5)} />,
     });
   }
 

--- a/static/app/views/insights/agentMonitoring/utils/urlParams.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/urlParams.tsx
@@ -1,0 +1,4 @@
+export enum DrawerUrlParams {
+  SELECTED_SPAN = 'span',
+  SELECTED_TRACE = 'trace',
+}


### PR DESCRIPTION
## Summary

Add `useLocationSyncedState` for syncing URL and state without UI lag.
Store selected span in URL & update drawer URL param to use the new util.
Render provider icon next to name in span details.

- closes [TET-733: Put span id into URL when clicking on spans inside the drawer so that it can be shared with others](https://linear.app/getsentry/issue/TET-733/put-span-id-into-url-when-clicking-on-spans-inside-the-drawer-so-that)
- closes [TET-732: Provider logo inside span details](https://linear.app/getsentry/issue/TET-732/provider-logo-inside-span-details)

## Test plan

- [ ] Navigate to AI monitoring trace drawer
- [ ] Click on different spans in the trace list
- [ ] Verify that the URL updates with the selected span ID
- [ ] Share the URL and confirm the same span is selected when opening
- [ ] Test rapid clicking between spans to ensure smooth navigation
- [ ] Verify provider icons are displayed correctly in span details

🤖 Generated with [Claude Code](https://claude.ai/code)