### PR TITLE
ref(workflow_engine): Refactor StatefulDetectorHandler + StatefulGroupingDetectorHandler

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -7,19 +7,16 @@ from typing import Any
 from sentry import features
 from sentry.incidents.metric_alert_detector import MetricAlertsDetectorValidator
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, ComparisonDeltaChoices
-from sentry.incidents.utils.types import MetricDetectorUpdate, QuerySubscriptionUpdate
+from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.handlers.detector import (
-    DetectorOccurrence,
-    StatefulGroupingDetectorHandler,
-)
+from sentry.workflow_engine.handlers.detector import DetectorOccurrence, StatefulDetectorHandler
 from sentry.workflow_engine.handlers.detector.base import EvidenceData
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
-from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel, DetectorSettings
+from sentry.workflow_engine.types import DetectorPriorityLevel, DetectorSettings
 
 COMPARISON_DELTA_CHOICES: list[None | int] = [choice.value for choice in ComparisonDeltaChoices]
 COMPARISON_DELTA_CHOICES.append(None)
@@ -30,7 +27,7 @@ class MetricIssueEvidenceData(EvidenceData):
     alert_id: int
 
 
-class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscriptionUpdate, int]):
+class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate, int]):
     def create_occurrence(
         self,
         evaluation_result: ProcessedDataConditionGroup,
@@ -47,21 +44,11 @@ class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscripti
         )
         return occurrence, {}
 
-    @property
-    def counter_names(self) -> list[str]:
-        # Placeholder for now, this should be a list of counters that we want to update as we go above warning / critical
-        return []
-
     def extract_dedupe_value(self, data_packet: DataPacket[QuerySubscriptionUpdate]) -> int:
         return int(data_packet.packet.get("timestamp", datetime.now(UTC)).timestamp())
 
     def extract_value(self, data_packet: DataPacket[QuerySubscriptionUpdate]) -> int:
         return data_packet.packet["values"]["value"]
-
-    def extract_group_values(
-        self, data_packet: DataPacket[MetricDetectorUpdate]
-    ) -> dict[DetectorGroupKey, int]:
-        return {None: data_packet.packet["values"]["value"]}
 
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -46,7 +46,6 @@ from sentry.incidents.utils.process_update_helpers import (
 )
 from sentry.incidents.utils.types import (
     DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
-    MetricDetectorUpdate,
     QuerySubscriptionUpdate,
 )
 from sentry.models.project import Project
@@ -336,13 +335,13 @@ class SubscriptionProcessor:
 
         if aggregation_value is not None:
             if has_metric_alert_processing:
-                packet = MetricDetectorUpdate(
+                packet = QuerySubscriptionUpdate(
                     entity=subscription_update.get("entity", ""),
                     subscription_id=subscription_update["subscription_id"],
                     values={"value": aggregation_value},
                     timestamp=self.last_update,
                 )
-                data_packet = DataPacket[MetricDetectorUpdate](
+                data_packet = DataPacket[QuerySubscriptionUpdate](
                     source_id=str(self.subscription.id), packet=packet
                 )
                 # temporarily skip processing any anomaly detection alerts

--- a/src/sentry/incidents/utils/types.py
+++ b/src/sentry/incidents/utils/types.py
@@ -10,13 +10,6 @@ class QuerySubscriptionUpdate(TypedDict):
     timestamp: datetime
 
 
-class MetricDetectorUpdate(TypedDict):
-    entity: str
-    subscription_id: str
-    values: Any
-    timestamp: datetime
-
-
 class AlertRuleActivationConditionType(Enum):
     RELEASE_CREATION = 0
     DEPLOY_CREATION = 1

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -4,8 +4,8 @@ __all__ = [
     "DetectorHandler",
     "DetectorOccurrence",
     "DetectorStateData",
-    "StatefulGroupingDetectorHandler",
+    "StatefulDetectorHandler",
 ]
 
 from .base import DataPacketEvaluationType, DataPacketType, DetectorHandler, DetectorOccurrence
-from .stateful import DetectorStateData, StatefulGroupingDetectorHandler
+from .stateful import DetectorStateData, StatefulDetectorHandler

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -22,7 +22,6 @@ logger = logging.getLogger(__name__)
 DataPacketType = TypeVar("DataPacketType")
 DataPacketEvaluationType = TypeVar("DataPacketEvaluationType")
 
-# TODO - get more info about how this is used in issue platform
 EventData = dict[str, Any]
 
 
@@ -79,7 +78,6 @@ class DetectorOccurrence:
         )
 
 
-# TODO - DetectorHandler -> AbstractDetectorHandler? (then DetectorHandler is the base implementation)
 class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]):
     def __init__(self, detector: Detector):
         self.detector = detector
@@ -125,7 +123,9 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]
         pass
 
     @abc.abstractmethod
-    def extract_value(self, data_packet: DataPacket[DataPacketType]) -> DataPacketEvaluationType:
+    def extract_value(
+        self, data_packet: DataPacket[DataPacketType]
+    ) -> DataPacketEvaluationType | dict[DetectorGroupKey, DataPacketEvaluationType]:
         """
         Extracts the evaluation value from the data packet to be processed.
 
@@ -133,11 +133,10 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]
         """
         pass
 
-    # TODO should this be a required method? :thinking:
     @abc.abstractmethod
     def extract_dedupe_value(self, data_packet: DataPacket[DataPacketType]) -> int:
         """
-        Extracts the deduplication value from a passed data packet. This duplication
+        Extracts the de-duplication value from a passed data packet. This duplication
         value is used to determine if we've already processed data to this point or not.
 
         This is normally a timestamp, but could be any sortable value; (e.g. a sequence number, timestamp, etc).

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -1,7 +1,7 @@
 import abc
 import dataclasses
 from datetime import UTC, datetime, timedelta
-from typing import Generic
+from typing import Generic, cast
 from uuid import uuid4
 
 from django.conf import settings
@@ -18,6 +18,7 @@ from sentry.workflow_engine.handlers.detector.base import (
     DataPacketType,
     DetectorHandler,
     DetectorOccurrence,
+    EventData,
 )
 from sentry.workflow_engine.models import DataPacket, Detector, DetectorState
 from sentry.workflow_engine.processors.data_condition_group import (
@@ -62,6 +63,7 @@ class DetectorStateData:
     counter_updates: DetectorCounters
 
 
+# TODO - we might want to extract this into another file to reduce noise in this file.
 class DetectorStateManager:
     dedupe_updates: dict[DetectorGroupKey, int] = {}
     counter_updates: dict[DetectorGroupKey, DetectorCounters] = {}
@@ -295,6 +297,164 @@ class StatefulDetectorHandler(
         """
         return {}
 
+    def build_issue_fingerprint(self, group_key: DetectorGroupKey = None) -> list[str]:
+        """
+        A hook that allows for additional fingerprinting to be added to the detectors issue occurrences.
+        By default the fingerprint will be the detector id and group key.
+        """
+        return []
+
+    def evaluate(
+        self, data_packet: DataPacket[DataPacketType]
+    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
+        dedupe_value = self.extract_dedupe_value(data_packet)
+        group_data_values = self._extract_value_from_packet(data_packet)
+        state = self.state_manager.get_state_data(list(group_data_values.keys()))
+        results: dict[DetectorGroupKey, DetectorEvaluationResult] = {}
+
+        for group_key in group_data_values.keys():
+            state_data: DetectorStateData = state[group_key]
+            if dedupe_value <= state_data.dedupe_value:
+                metrics.incr("workflow_engine.detector.skipping_already_processed_update")
+                continue
+
+            self.state_manager.enqueue_dedupe_update(group_key, dedupe_value)
+
+            evaluated_priority, condition_results = self._evaluate_value(
+                group_data_values[group_key],
+                state_data,
+            )
+
+            if evaluated_priority is None or condition_results is None:
+                continue
+
+            updated_threshold_counts = self._increment_detector_thresholds(
+                state_data, evaluated_priority, group_key
+            )
+
+            new_priority = self._has_breached_threshold(updated_threshold_counts)
+            if new_priority is None:
+                # We haven't met any thresholds yet, so continue checking
+                continue
+
+            self.state_manager.enqueue_state_update(
+                group_key,
+                new_priority != DetectorPriorityLevel.OK,
+                new_priority,
+            )
+
+            results[group_key] = self._build_detector_evaluation_result(
+                group_key,
+                new_priority,
+                condition_results,
+                data_packet,
+            )
+
+        self.state_manager.commit_state_updates()
+        return results
+
+    def _create_resolve_message(self, group_key: DetectorGroupKey = None) -> StatusChangeMessage:
+        fingerprint = [
+            *self.build_issue_fingerprint(),
+            self.state_manager.build_key(group_key),
+        ]
+
+        return StatusChangeMessage(
+            fingerprint=fingerprint,
+            project_id=self.detector.project_id,
+            new_status=GroupStatus.RESOLVED,
+            new_substatus=None,
+        )
+
+    def _extract_value_from_packet(
+        self,
+        data_packet: DataPacket[DataPacketType],
+    ) -> dict[DetectorGroupKey, DataPacketEvaluationType]:
+        """
+        This method will normalize the extracted value to support grouping results.
+
+        If `extract_value` returns a `dict[DetectorGroupKey, DataPacketEvaluationType]`
+        it will cast it to the correct data type.
+
+        If `extract_value` returns a single value, it will be wrapped in a dict
+        with `None` as the key, to normalize the type as `dict[DetectorGroupKey, DataPacketEvaluationType]`.
+        """
+        data_values = self.extract_value(data_packet)
+        group_data_values: dict[DetectorGroupKey, DataPacketEvaluationType] = {}
+
+        # Normalize the type to dict[DetectorGroupKey, DataPacketEvaluationType]
+        if self._is_detector_group_value(data_values):
+            group_data_values = cast(dict[DetectorGroupKey, DataPacketEvaluationType], data_values)
+        else:
+            group_data_values = {None: cast(DataPacketEvaluationType, data_values)}
+
+        return group_data_values
+
+    def _build_detector_evaluation_result(
+        self,
+        group_key: DetectorGroupKey,
+        new_priority: DetectorPriorityLevel,
+        condition_results: ProcessedDataConditionGroup,
+        data_packet: DataPacket[DataPacketType],
+    ) -> DetectorEvaluationResult:
+        detector_result: IssueOccurrence | StatusChangeMessage
+        event_data: EventData | None = None
+
+        if new_priority == DetectorPriorityLevel.OK:
+            # Call the `create_resolve_message` method to create the status change.
+            detector_result = self._create_resolve_message(group_key)
+            self.state_manager.enqueue_counter_reset(group_key)
+        else:
+            # Call the `create_occurrence` method to create the detector occurrence.
+            detector_occurrence, event_data = self.create_occurrence(
+                condition_results, data_packet, new_priority
+            )
+            detector_result = self._create_decorated_issue_occurrence(
+                detector_occurrence, condition_results, new_priority, group_key
+            )
+
+            # Set the event data with the necessary fields
+            event_data["timestamp"] = detector_result.detection_time
+            event_data["project_id"] = detector_result.project_id
+            event_data["event_id"] = detector_result.event_id
+            event_data.setdefault("platform", "python")
+            event_data.setdefault("received", detector_result.detection_time)
+            event_data.setdefault("tags", {})
+
+        return DetectorEvaluationResult(
+            group_key=group_key,
+            is_triggered=new_priority != DetectorPriorityLevel.OK,
+            priority=new_priority,
+            result=detector_result,
+            event_data=event_data,
+        )
+
+    def _is_detector_group_value(self, value) -> bool:
+        """
+        Check if value is dict[DetectorGroupKey, DataPacketEvaluationType]
+        """
+        if not isinstance(value, dict):
+            return False
+
+        if not value:  # Empty dict case
+            return False
+
+        # Check if all keys are DetectorGroupKey instances
+        return all(isinstance(key, DetectorGroupKey) for key in value.keys())
+
+    def _evaluate_value(
+        self,
+        value: DataPacketEvaluationType,
+        state: DetectorStateData,
+    ) -> tuple[DetectorPriorityLevel | None, ProcessedDataConditionGroup | None]:
+        condition_results, new_priority = self._evaluation_detector_conditions(value)
+
+        is_status_changed = state.status != new_priority
+        if not is_status_changed or condition_results is None:
+            return None, condition_results
+
+        return new_priority, condition_results
+
     def _get_configured_detector_levels(self) -> list[DetectorPriorityLevel]:
         priority_levels: list[DetectorPriorityLevel] = [level for level in DetectorPriorityLevel]
 
@@ -302,8 +462,7 @@ class StatefulDetectorHandler(
             return []
 
         # TODO - Is this something that should be provided by the detector itself rather
-        # than having to query the db for each level? Maybe we can cache this on the detector
-        # so we reduce the number of queries throughout the system.
+        # than having to query the db for each level?
         condition_result_levels = self.detector.workflow_condition_group.conditions.filter(
             condition_result__in=priority_levels
         ).values_list("condition_result", flat=True)
@@ -315,6 +474,7 @@ class StatefulDetectorHandler(
         detector_occurrence: DetectorOccurrence,
         evaluation_result: ProcessedDataConditionGroup,
         new_priority: DetectorPriorityLevel,
+        group_key: DetectorGroupKey,
     ) -> IssueOccurrence:
         """
         Decorate the issue occurrence with the data from the detector's evaluation result.
@@ -328,13 +488,18 @@ class StatefulDetectorHandler(
             ],
         }
 
+        fingerprint = [
+            *self.build_issue_fingerprint(group_key),
+            self.state_manager.build_key(group_key),
+        ]
+
         return detector_occurrence.to_issue_occurrence(
+            fingerprint=fingerprint,
             occurrence_id=str(uuid4()),
             project_id=self.detector.project_id,
             status=new_priority,
             detection_time=datetime.now(UTC),
             additional_evidence_data=evidence_data,
-            fingerprint=[self.state_manager.build_key()],
         )
 
     def _evaluation_detector_conditions(
@@ -384,25 +549,6 @@ class StatefulDetectorHandler(
         self.state_manager.enqueue_counter_update(group_key, results)
         return results
 
-    def build_issue_fingerprint(self, group_key: DetectorGroupKey = None) -> list[str]:
-        """
-        A hook that allows for additional fingerprinting to be added to the detectors issue occurrences.
-        By default the fingerprint will be the detector id and group key.
-        """
-        return []
-
-    def create_resolve_message(self) -> StatusChangeMessage:
-        """
-        Create a resolve message for the detectors issue. This is overridable in the subclass, but
-        will work for the majority of cases.
-        """
-        return StatusChangeMessage(
-            fingerprint=[*self.build_issue_fingerprint(), self.state_manager.build_key()],
-            project_id=self.detector.project_id,
-            new_status=GroupStatus.RESOLVED,
-            new_substatus=None,
-        )
-
     def _has_breached_threshold(
         self,
         updated_threshold_counts: DetectorCounters,
@@ -422,198 +568,3 @@ class StatefulDetectorHandler(
                 return level
 
         return None
-
-    def evaluate(
-        self, data_packet: DataPacket[DataPacketType]
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult] | None:
-        """
-        This method evaluates the detector's conditions against the data packet's value.
-
-        If the conditions are met, it will call `create_occurrence` in the implementing class
-        to create a detector occurrence.
-        """
-        detector_result: IssueOccurrence | StatusChangeMessage
-        event_data = None
-
-        # TODO ensure this is not a duplicate packet or reprocessing
-
-        value = self.extract_value(data_packet)
-        is_condition_group_met, new_priority = self._evaluation_detector_conditions(value)
-        state = self.state_manager.get_state_data([None])[None]
-
-        is_status_changed = state.status != new_priority
-        if not is_condition_group_met or not is_status_changed:
-            # If the condition is not met or the status is not the same, nothing to do.
-            return None
-
-        updated_threshold_counts = self._increment_detector_thresholds(state, new_priority, None)
-        highest_breached_threshold = self._has_breached_threshold(updated_threshold_counts)
-        if highest_breached_threshold is None:
-            # We haven't met any of the thresholds yet, so don't trigger
-            return None
-
-        new_priority = highest_breached_threshold
-
-        if new_priority == DetectorPriorityLevel.OK:
-            detector_result = self.create_resolve_message()
-            self.state_manager.enqueue_counter_reset()
-        else:
-            detector_occurrence, event_data = self.create_occurrence(
-                is_condition_group_met, data_packet, new_priority
-            )
-            detector_result = self._create_decorated_issue_occurrence(
-                detector_occurrence, is_condition_group_met, new_priority
-            )
-
-        return {
-            None: DetectorEvaluationResult(
-                group_key=None,
-                is_triggered=new_priority != DetectorPriorityLevel.OK,
-                priority=new_priority,
-                result=detector_result,
-                event_data=event_data,
-            )
-        }
-
-
-class StatefulGroupingDetectorHandler(
-    Generic[DataPacketType, DataPacketEvaluationType],
-    StatefulDetectorHandler[DataPacketType, DataPacketEvaluationType],
-    abc.ABC,
-):
-    def extract_group_values(
-        self, data_packet: DataPacket[DataPacketType]
-    ) -> dict[DetectorGroupKey, DataPacketEvaluationType] | None:
-        """
-        Extracts the values for all the group keys that exist in the given data packet,
-        and returns then as a dict keyed by group_key.
-        """
-        return None
-
-    def evaluate(
-        self, data_packet: DataPacket[DataPacketType]
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
-        """
-        Overrides the base evaluation method, to evaluate in groups instead.
-        """
-        return self.evaluate_groups(data_packet)
-
-    def evaluate_groups(
-        self,
-        data_packet: DataPacket[DataPacketType],
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
-        dedupe_value = self.extract_dedupe_value(data_packet)
-        group_values = self.extract_group_values(data_packet) or {}
-        all_state_data = self.state_manager.get_state_data(list(group_values.keys()))
-        results = {}
-
-        for group_key, group_value in group_values.items():
-            result = self.evaluate_group_key_value(
-                group_key,
-                group_value,
-                all_state_data[group_key],
-                dedupe_value,
-                data_packet,
-            )
-
-            if result:
-                results[result.group_key] = result
-
-        self.state_manager.commit_state_updates()
-        return results
-
-    def evaluate_group_key_value(
-        self,
-        group_key: DetectorGroupKey,
-        value: DataPacketEvaluationType,
-        state_data: DetectorStateData,
-        dedupe_value: int,
-        data_packet: DataPacket[DataPacketType],
-    ) -> DetectorEvaluationResult | None:
-        """
-        Evaluates a value associated with a given `group_key` and returns a `DetectorEvaluationResult` with the results
-        and any state changes that need to be made.
-
-        Checks that we haven't already processed this data-packet for this group_key, and skips evaluation if we have.
-        """
-        if dedupe_value <= state_data.dedupe_value:
-            metrics.incr("workflow_engine.detector.skipping_already_processed_update")
-            return None
-
-        self.state_manager.enqueue_dedupe_update(group_key, dedupe_value)
-
-        if not self.condition_group:
-            metrics.incr("workflow_engine.detector.skipping_invalid_condition_group")
-            return None
-
-        new_priority = DetectorPriorityLevel.OK
-        is_condition_group_met, new_priority = self._evaluation_detector_conditions(value)
-        is_status_changed = state_data.status != new_priority
-
-        if not is_status_changed or not is_condition_group_met:
-            return None
-
-        # Update the counter for the new status
-        updated_threshold_count = self._increment_detector_thresholds(
-            state_data, new_priority, group_key
-        )
-
-        breached_threshold = self._has_breached_threshold(updated_threshold_count)
-        if breached_threshold is None:
-            # We haven't met the threshold yet, so don't trigger
-            return None
-
-        new_status = breached_threshold
-        is_triggered = new_status != DetectorPriorityLevel.OK
-        self.state_manager.enqueue_state_update(group_key, is_triggered, new_status)
-
-        result: StatusChangeMessage | IssueOccurrence
-        event_data = None
-
-        if new_status == DetectorPriorityLevel.OK:
-            result = StatusChangeMessage(
-                fingerprint=[
-                    *self.build_issue_fingerprint(group_key),
-                    self.state_manager.build_key(group_key),
-                ],
-                project_id=self.detector.project_id,
-                new_status=GroupStatus.RESOLVED,
-                new_substatus=None,
-            )
-
-            # Now that we've resolved the issue, we can reset the counters
-            self.state_manager.enqueue_counter_reset(group_key)
-        else:
-            detector_occurrence, event_data = self.create_occurrence(
-                is_condition_group_met, data_packet, new_status
-            )
-            evidence_data = {
-                **detector_occurrence.evidence_data,
-                "detector_id": self.detector.id,
-                "value": value,
-            }
-            result = detector_occurrence.to_issue_occurrence(
-                occurrence_id=str(uuid4()),
-                project_id=self.detector.project_id,
-                status=new_status,
-                detection_time=datetime.now(UTC),
-                additional_evidence_data=evidence_data,
-                fingerprint=[
-                    *self.build_issue_fingerprint(group_key),
-                    self.state_manager.build_key(group_key),
-                ],
-            )
-            event_data["timestamp"] = result.detection_time
-            event_data["project_id"] = result.project_id
-            event_data["event_id"] = result.event_id
-            event_data.setdefault("platform", "python")
-            event_data.setdefault("received", result.detection_time)
-            event_data.setdefault("tags", {})
-
-        return DetectorEvaluationResult(
-            group_key=group_key,
-            is_triggered=is_triggered,
-            priority=new_status,
-            result=result,
-            event_data=event_data,
-        )

--- a/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
@@ -152,7 +152,9 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
         self.handler.evaluate(self.data_packet)
         result = self.handler.evaluate(self.data_packet_two)
 
+        assert result
         evaluation_result = result[self.group_key]
+
         assert evaluation_result
         assert evaluation_result.priority == DetectorPriorityLevel.HIGH
         assert isinstance(evaluation_result.result, IssueOccurrence)
@@ -209,6 +211,8 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
         self.handler.evaluate(self.data_packet)
         self.handler.evaluate(self.data_packet_two)
         result = self.handler.evaluate(self.resolve_data_packet)
+
+        assert result
         evaluation_result = result[self.group_key]
 
         assert evaluation_result
@@ -244,6 +248,8 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
         assert result == {}
 
         result = self.handler.evaluate(self.data_packet_two)
+
+        assert result
         evaluation_result = result[self.group_key]
 
         assert evaluation_result

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -446,7 +446,6 @@ class TestEvaluate(BaseDetectorHandlerTest):
     def test_above_below_threshold(self):
         handler = self.build_handler()
         assert handler.evaluate(DataPacket("1", {"dedupe": 1, "group_vals": {"val1": 0}})) == {}
-        handler.state_manager.commit_state_updates()
 
         detector_occurrence, _ = build_mock_occurrence_and_event(
             handler, "val1", PriorityLevel.HIGH
@@ -605,7 +604,7 @@ class TestEvaluate(BaseDetectorHandlerTest):
 
 
 @freeze_time()
-class TestEvaluateGroupKeyValue(BaseDetectorHandlerTest):
+class TestEvaluateGroupValue(BaseDetectorHandlerTest):
     def test_dedupe(self):
         handler = self.build_handler()
         with mock.patch(
@@ -633,38 +632,46 @@ class TestEvaluateGroupKeyValue(BaseDetectorHandlerTest):
                 result=issue_occurrence,
                 event_data=event_data,
             )
-            assert (
-                handler.evaluate_group_key_value(
-                    expected_result.group_key,
-                    10,
-                    DetectorStateData(
-                        "group_key",
-                        False,
-                        DetectorPriorityLevel.OK,
-                        99,
-                        {},
-                    ),
-                    100,
-                    DataPacket[dict](source_id="1234", packet={"id": "1234", "value": "1"}),
-                )
-                == expected_result
+
+            handler.state_manager.enqueue_state_update(
+                "group_key",
+                False,
+                DetectorPriorityLevel.OK,
             )
+            handler.state_manager.enqueue_dedupe_update("group_key", 99)
+            handler.state_manager.commit_state_updates()
+
+            data_packet = DataPacket[dict](
+                source_id="1234",
+                packet={"id": "1234", "group_vals": {"group_key": 10}, "dedupe": 100},
+            )
+            result = handler.evaluate(data_packet)
+            if not result:
+                raise AssertionError("Expected result to not be empty")
+
+            assert result["group_key"] == expected_result
             assert not mock_metrics.incr.called
-            assert (
-                handler.evaluate_group_key_value(
-                    expected_result.group_key,
-                    1,
-                    DetectorStateData(
-                        "group_key",
-                        False,
-                        DetectorPriorityLevel.OK,
-                        100,
-                        {},
-                    ),
-                    100,
-                    DataPacket[dict](source_id="1234", packet={"id": "1234", "value": "1"}),
-                )
-                is None
+
+    def test_dedupe__already_processed(self):
+        handler = self.build_handler()
+
+        with mock.patch(
+            "sentry.workflow_engine.handlers.detector.stateful.metrics"
+        ) as mock_metrics:
+            handler.state_manager.enqueue_state_update(
+                "group_key",
+                False,
+                DetectorPriorityLevel.OK,
+            )
+
+            handler.state_manager.enqueue_dedupe_update("group_key", 100)
+            handler.state_manager.commit_state_updates()
+
+            handler.evaluate(
+                DataPacket[dict](
+                    source_id="1234",
+                    packet={"id": "1234", "group_vals": {"group_key": 10}, "dedupe": 100},
+                ),
             )
             mock_metrics.incr.assert_called_once_with(
                 "workflow_engine.detector.skipping_already_processed_update"
@@ -672,41 +679,31 @@ class TestEvaluateGroupKeyValue(BaseDetectorHandlerTest):
 
     def test_status_change(self):
         handler = self.build_handler()
-        result = handler.evaluate_group_key_value(
-            "group_key",
-            0,
-            DetectorStateData(
-                "group_key",
-                False,
-                DetectorPriorityLevel.OK,
-                1,
-                {},
-            ),
-            2,
-            DataPacket[dict](source_id="1234", packet={"id": "1234", "value": "1"}),
+        data_packet = DataPacket[dict](
+            source_id="1234", packet={"id": "1234", "group_vals": {"group_key": 10}, "dedupe": 100}
         )
 
-        assert result is None
-        assert handler.evaluate_group_key_value(
-            "group_key",
-            0,
-            DetectorStateData(
-                "group_key",
-                True,
-                DetectorPriorityLevel.HIGH,
-                1,
-                {},
-            ),
-            2,
-            DataPacket[dict](source_id="1234", packet={"id": "1234", "value": "1"}),
-        ) == DetectorEvaluationResult(
-            "group_key",
-            False,
-            DetectorPriorityLevel.OK,
-            result=StatusChangeMessage(
-                fingerprint=[f"{handler.detector.id}:group_key"],
-                project_id=self.project.id,
-                new_status=1,
-                new_substatus=None,
-            ),
-        )
+        assert handler.state_manager.get_state_data(["group_key"]) == {
+            "group_key": DetectorStateData(
+                group_key="group_key",
+                is_triggered=False,
+                status=DetectorPriorityLevel.OK,
+                dedupe_value=0,
+                counter_updates={level: None for level in handler._thresholds},
+            )
+        }
+
+        handler.evaluate(data_packet)
+
+        assert handler.state_manager.get_state_data(["group_key"]) == {
+            "group_key": DetectorStateData(
+                group_key="group_key",
+                is_triggered=True,
+                status=DetectorPriorityLevel.HIGH,
+                dedupe_value=100,
+                counter_updates={
+                    **{level: None for level in handler._thresholds},
+                    DetectorPriorityLevel.HIGH: 1,
+                },
+            )
+        }


### PR DESCRIPTION
# Description
- Merge the Grouping handler back into the stateful handler, as I was
progressing in refactoring it away, i found myself hardcoding `none` a
lot for the shared helpers. So refactored this to merge them a bit more
together, this will take away the difficulty for implementing a stateful
detector handler, but not reduce all the complexity in the class (seems
like a reasonable tradeoff for now)
- Update the Metric Alert detector to use the new handler.