### PR TITLE
Fix bounds checking in migration 0925 backfill logic

### DIFF
--- a/src/sentry/migrations/0925_backfill_open_periods.py
+++ b/src/sentry/migrations/0925_backfill_open_periods.py
@@ -70,7 +70,10 @@ def get_open_periods_for_group(
     # Since activities can apparently exist from before the start date, we want to ensure the
     # first open period starts at the first_seen date and ends at the first resolution activity after it.
     start_index = 0
-    while activities and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:
+    activities_len = len(activities)
+    while (
+        start_index < activities_len and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES
+    ):
         start_index += 1
 
     open_periods = []


### PR DESCRIPTION
## Summary
- Fixes IndexError in migration 0925 when processing groups with no resolved activities
- Adds proper bounds checking to prevent array access violations  
- Ensures migration completes successfully for all group activity patterns

## Changes
- Add length check before accessing activities array in while loop
- Prevents IndexError when start_index exceeds activities length
- Maintains existing migration logic while adding safety bounds

This fix resolves production migration failures where groups had only regression activities without corresponding resolution activities, causing the migration to crash with IndexError.

## Bug Details
The original code had:
```python
while activities and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:
    start_index += 1  # BUG: No bounds checking\!
```

This would cause IndexError when `start_index` exceeded the array length.

The fix adds proper bounds checking:
```python
activities_len = len(activities)
while (
    start_index < activities_len and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES
):
    start_index += 1
```

🤖 Generated with [Claude Code](https://claude.ai/code)